### PR TITLE
Remove elsim from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,5 @@
 build
 demos
 dist
-elsim
 examples
 test


### PR DESCRIPTION
elsim package needed for androsim

```
root@96d9de32b69e:/opt/androguard# androsim.py
Traceback (most recent call last):
  File "/usr/local/bin/androsim.py", line 4, in <module>
    __import__('pkg_resources').run_script('androguard==3.0', 'androsim.py')
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python2.7/site-packages/androguard-3.0-py2.7.egg/EGG-INFO/scripts/androsim.py", line 31, in <module>

ImportError: No module named elsim
```